### PR TITLE
Fixes build tools not noticing changes in the modular folder

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -216,6 +216,7 @@ export const DmTarget = new Juke.Target({
     'html/**',
     'icons/**',
     'interface/**',
+	'wallstation_modules/**', ///WALLSTATION EDIT: Stops the build tool from skipping changes in the modular folder
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -216,7 +216,7 @@ export const DmTarget = new Juke.Target({
     'html/**',
     'icons/**',
     'interface/**',
-	'wallstation_modules/**', ///WALLSTATION EDIT: Stops the build tool from skipping changes in the modular folder
+    'wallstation_modules/**', ///WALLSTATION EDIT: Stops the build tool from skipping changes in the modular folder
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says. VScode wouldn't automatically rebuild if you only made changes in the modular folder.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Dev tools should work actually.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
