### PR TITLE
[modular] Removes FOV from atmos gas mask and captain gas mask

### DIFF
--- a/wallstation_modules/gas-mask-fov-override/code/gas-mask-fov-override.dm
+++ b/wallstation_modules/gas-mask-fov-override/code/gas-mask-fov-override.dm
@@ -1,0 +1,3 @@
+/// ORIGINAL FILE: code\modules\clothing\masks\gasmask.dm
+/obj/item/clothing/mask/gas/atmos
+	has_fov = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Discord thread: https://discord.com/channels/1271647269845864601/1273913749522223218
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Normal gas mask FOV is still there since they are so abundant.
- Improved versions of the gas mask can have no FOV are limited so it's ok for them to be more powerful.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: grungussusss
balance: Atmospheric and Captain gas mask have no FOV
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
