### PR TITLE
(MIRROR) THE WIRING (add wire information for pretty much everything, for the appropriate roles)

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -778,6 +778,27 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	. = view(range, GLOB.dview_mob)
 	GLOB.dview_mob.loc = null
 
+/proc/is_syndicate_affiliated(mob/suspect)
+	var/static/list/syndie_scum = list(
+		ROLE_TRAITOR,
+		ROLE_SYNDICATE,
+		ROLE_SYNDICATE_INFILTRATOR,
+		ROLE_SYNDICATE_ASSAULTBORG,
+		ROLE_SYNDICATE_CYBERSUN,
+		ROLE_SYNDICATE_CYBERSUN_CAPTAIN,
+		ROLE_SYNDICATE_MEDBORG,
+		ROLE_SPACE_SYNDICATE,
+		ROLE_LAVALAND_SYNDICATE,
+		ROLE_SLEEPER_AGENT,
+		ROLE_BATTLECRUISER_CAPTAIN,
+		ROLE_BATTLECRUISER_CREW,
+		ROLE_NUCLEAR_OPERATIVE,
+		ROLE_CONTRACTOR_SUPPORT
+	)
+	if(syndie_scum.Find(suspect?.mind?.special_role))
+		return TRUE
+	return FALSE
+
 /mob/dview
 	name = "INTERNAL DVIEW MOB"
 	invisibility = INVISIBILITY_ABSTRACT

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -41,6 +41,9 @@
 	/// If every instance of these wires should be random. Prevents wires from showing up in station blueprints.
 	var/randomize = FALSE
 
+	/// The trait someone needs in order to see these wires
+	var/my_wire_trait = TRAIT_KNOW_ENGI_WIRES
+
 	/// Lazy assoc list of refs to mobs to refs to photos they have studied for wires
 	var/list/studied_photos
 
@@ -268,6 +271,10 @@
 			for(var/obj/item/photo/photo in user.held_items)
 				if(LAZYACCESS(studied_photos, REF(user.mind)) == REF(photo))
 					return TRUE
+
+	// If an engineer shouldn't know these wires, we can override this for another trait
+	if(HAS_TRAIT(user, my_wire_trait))
+		return TRUE
 
 	return FALSE
 

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -85,9 +85,3 @@
 			A.locked = !mend
 		if(WIRE_AI) // Disable AI control.
 			A.aidisabled = !mend
-
-/datum/wires/apc/can_reveal_wires(mob/user)
-	if(HAS_TRAIT(user, TRAIT_KNOW_ENGI_WIRES))
-		return TRUE
-
-	return ..()

--- a/code/datums/wires/collar_bomb.dm
+++ b/code/datums/wires/collar_bomb.dm
@@ -3,6 +3,7 @@
 	randomize = TRUE // Only one wire, no need for blueprints
 	holder_type = /obj/item/clothing/neck/collar_bomb
 	wires = list(WIRE_ACTIVATE)
+	my_wire_trait = null
 
 /datum/wires/collar_bomb/interactable(mob/user)
 	. = ..()
@@ -27,6 +28,11 @@
 			triggerer = get_mob_by_key(assembly.fingerprintslast)
 	brian.investigate_log("has had their [collar] triggered [triggerer ? "by [user || assembly][assembly ? " last touched by triggerer" : ""]" : ""].", INVESTIGATE_DEATHS)
 	return ..()
+
+/datum/wires/collar_bomb/can_reveal_wires(mob/user)
+	return FALSE
+
+
 
 ///I'd rather not get people killed by EMP here.
 /datum/wires/collar_bomb/emp_pulse()

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -2,10 +2,20 @@
 	var/duds_number = 2 // All "dud" wires cause an explosion when cut or pulsed
 	proper_name = "Explosive Device"
 	randomize = TRUE // Prevents wires from showing up on blueprints
+	my_wire_trait = null
 
 /datum/wires/explosive/New(atom/holder)
 	add_duds(duds_number) // Duds also explode here.
 	..()
+
+/datum/wires/explosive/can_reveal_wires(mob/user)
+	. = ..()
+	if (.)
+		return .
+	. = FALSE
+	if(is_syndicate_affiliated(user))
+		. = TRUE
+	return .
 
 /datum/wires/explosive/on_pulse(index)
 	explode()

--- a/code/datums/wires/mecha.dm
+++ b/code/datums/wires/mecha.dm
@@ -1,6 +1,7 @@
 /datum/wires/mecha
 	holder_type = /obj/vehicle/sealed/mecha
 	proper_name = "Mecha Control"
+	my_wire_trait = TRAIT_KNOW_ROBO_WIRES
 
 /datum/wires/mecha/New(atom/holder)
 	wires = list(WIRE_IDSCAN, WIRE_DISARM, WIRE_ZAP, WIRE_OVERCLOCK, WIRE_LAUNCH)

--- a/code/datums/wires/mod.dm
+++ b/code/datums/wires/mod.dm
@@ -1,6 +1,7 @@
 /datum/wires/mod
 	holder_type = /obj/item/mod/control
 	proper_name = "MOD control unit"
+	my_wire_trait = TRAIT_KNOW_ROBO_WIRES
 
 /datum/wires/mod/New(atom/holder)
 	wires = list(WIRE_HACK, WIRE_DISABLE, WIRE_SHOCK, WIRE_INTERFACE)

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -2,6 +2,7 @@
 	holder_type = /mob/living/silicon/robot
 	proper_name = "Cyborg"
 	randomize = TRUE
+	my_wire_trait = TRAIT_KNOW_ROBO_WIRES
 
 /datum/wires/robot/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/syndicatebomb
 	proper_name = "Syndicate Explosive Device"
 	randomize = TRUE
+	my_wire_trait = null
 
 /datum/wires/syndicatebomb/New(atom/holder)
 	wires = list(
@@ -105,6 +106,16 @@
 				B.update_appearance()
 				if(isliving(usr))
 					add_memory_in_range(B, 7, /datum/memory/bomb_defuse_success, protagonist = usr, antagonist = B, bomb_time_left = bomb_time_left)
+
+/datum/wires/syndicatebomb/can_reveal_wires(mob/user)
+	. = ..()
+	if(.)
+		return .
+	. = FALSE
+	if(is_syndicate_affiliated(user))
+		. = TRUE
+	return .
+
 
 /datum/wires/syndicatebomb/proc/tell_admins(obj/machinery/syndicatebomb/B)
 	var/turf/T = get_turf(B)


### PR DESCRIPTION
## About The Pull Request

Right now the information for wires is determined by redefining a proc on every child of the wires datum. I redid this, so now that it consults a variable on every child of the datum instead. The variable is set to engineers knowing the wires by default. The stuff roboticists know has its variable set for them instead. Wires for badguy stuff that has wires (right now just bombs) instead checks to see if you're a Syndicate role (traitor, nukie, sleeper, contractor support, syndie monkey, syndie borg, etc). Engineers wouldn't know the wires to a syndicate bomb, and neither would some heretic or a wizard.

![wireguy1](https://github.com/user-attachments/assets/9e99f7e3-0b7d-40a5-b3dc-17a9af924b82)
![wireguy2](https://github.com/user-attachments/assets/5f01631c-6ed6-441d-b271-4065fa1418ce)
![wireguy_goodie](https://github.com/user-attachments/assets/ca13fdfd-215e-4a05-baa8-6c52d3b0b42d)
![wireguy_dastardly](https://github.com/user-attachments/assets/c41d5bac-2b20-42db-bc33-19580693b676)
## Why It's Good For The Game

Engineers should know wires for stuff because they have a skillchip for knowing wires for stuff and stuff whose wires you can know is just kinda random right now.
Cleans up code for knowing wires a bit.
Adds a helper for seeing if a given rando is affiliated with the syndicate, for if we wanna know that for other stuff.
## Changelog
:cl:Bisar
add: Engineer skillchips know the wires for most things by default. They don't know the wires for syndicate devices, though... but Syndicate-aligned antagonists do.
qol: Added a helper for seeing if a given player mob's mind is affiliated with the Syndicate.
code: Cleaned up the code for knowing wires to be more modular.
/:cl:
